### PR TITLE
Add local ai-context configuration

### DIFF
--- a/ai-context.yml
+++ b/ai-context.yml
@@ -1,0 +1,9 @@
+# Dieses Repo IST Heimgeist.
+# Für systemweite Policies siehe:
+#   metarepo/ai-contexts/heimgeist.ai-context.yml
+#
+# Lokale Identität:
+# Heimgeist denkt, bewertet, reflektiert und orchestriert systemweit.
+#
+extends:
+  heimgeist: "../metarepo/ai-contexts/heimgeist.ai-context.yml"


### PR DESCRIPTION
## Summary
- add local ai-context configuration pointing to shared heimgeist policy
- document local identity for Heimgeist in repository context file

## Testing
- not run (not needed for config change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69297ede09f0832c840388b4d443a06d)