### PR TITLE
Add local AI context and repo overview

### DIFF
--- a/ai-context.yml
+++ b/ai-context.yml
@@ -1,0 +1,9 @@
+# Dieses Repo IST Heimgeist.
+# Für systemweite Policies siehe:
+#   metarepo/ai-contexts/heimgeist.ai-context.yml
+#
+# Lokale Identität:
+# Heimgeist denkt, bewertet, reflektiert und orchestriert systemweit.
+#
+extends:
+  heimgeist: "../metarepo/ai-contexts/heimgeist.ai-context.yml"

--- a/ai-context.yml
+++ b/ai-context.yml
@@ -5,5 +5,4 @@
 # Lokale Identität:
 # Heimgeist denkt, bewertet, reflektiert und orchestriert systemweit.
 #
-extends:
-  heimgeist: "../metarepo/ai-contexts/heimgeist.ai-context.yml"
+extends: "../metarepo/ai-contexts/heimgeist.ai-context.yml"

--- a/docs/context.md
+++ b/docs/context.md
@@ -1,0 +1,13 @@
+# Heimgeist Kontext
+
+Heimgeist ist der systemweite Meta-Agent, der sämtliche Repos des
+Heimgewebes beobachtet, Risiken erkennt, Drift identifiziert und
+Reflexionsprozesse anstößt.
+
+Er nutzt:
+
+- chronik → Events
+- semantAH → semantische Einordnung
+- sichter → Analyse und Muster
+- wgx → Guard/Smoke
+- hausKI → orchestrierte Aktionen


### PR DESCRIPTION
## Summary
- add local ai-context configuration referencing metarepo policies
- document Heimgeist role and supporting components

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69297f0e230c832ca4afdfe401769c2f)