### PR TITLE
Add workflow to dispatch Heimgewebe commands

### DIFF
--- a/.github/workflows/heimgewebe-command-dispatch.yml
+++ b/.github/workflows/heimgewebe-command-dispatch.yml
@@ -1,0 +1,117 @@
+name: Heimgewebe Command Dispatch
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  dispatch:
+    name: Dispatch Heimgewebe Command
+    runs-on: ubuntu-latest
+
+    # Nur auf PR-Kommentare reagieren, die @heimgewebe/ enthalten
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@heimgewebe/')
+
+    steps:
+      - name: Kontext anzeigen (Debug)
+        run: |
+          echo "Repository: ${{ github.repository }}"
+          echo "PR:        #${{ github.event.issue.number }}"
+          echo "Author:    ${{ github.event.comment.user.login }}"
+          echo "Comment:"
+          echo "----------"
+          printf '%s\n' "${{ github.event.comment.body }}"
+          echo "----------"
+
+      - name: Heimgewebe-Kommando parsen
+        id: parse
+        env:
+          COMMENT_BODY: "${{ github.event.comment.body }}"
+          REPOSITORY: "${{ github.repository }}"
+          ISSUE_NUMBER: "${{ github.event.issue.number }}"
+          COMMENT_AUTHOR: "${{ github.event.comment.user.login }}"
+        run: |
+          python << 'PY'
+          import os, json, re, sys
+
+          body = os.environ["COMMENT_BODY"]
+          repo = os.environ["REPOSITORY"]
+          issue_number = int(os.environ["ISSUE_NUMBER"])
+          author = os.environ["COMMENT_AUTHOR"]
+
+          # Muster: @heimgewebe/<zielrepo> /kommando [arg…]
+          pattern = re.compile(r"@heimgewebe/([a-zA-Z0-9_-]+)\s+/(\S+)(.*)")
+          m = pattern.search(body)
+          if not m:
+              print("Kein gültiges Heimgewebe-Kommando gefunden.")
+              # Kein Fehler -> Job wird einfach beendet
+              sys.exit(0)
+
+          target_repo = m.group(1)
+          command = m.group(2)
+          args_raw = m.group(3).strip()
+
+          payload = {
+              "version": 1,
+              "source_repository": repo,
+              "source_issue_number": issue_number,
+              "source_comment_author": author,
+              "raw_comment": body,
+              "target_repo": target_repo,
+              "command": command,
+              "args": args_raw,
+          }
+
+          print("Erkannter Target-Repo:", target_repo)
+          print("Kommando:", command)
+          print("Argumente:", args_raw)
+
+          # Payload für nächste Steps ablegen
+          with open("command-payload.json", "w", encoding="utf-8") as f:
+              json.dump(payload, f)
+
+          # GITHUB_OUTPUT setzen
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+              f.write(f"target_repo={target_repo}\n")
+          PY
+
+      - name: Payload als Artefakt anzeigen
+        run: |
+          echo "command-payload.json:"
+          cat command-payload.json
+
+      - name: Repository Dispatch an Ziel-Repo senden
+        if: steps.parse.outputs.target_repo != ''
+        uses: actions/github-script@v7
+        env:
+          AUTOBOT_TOKEN: ${{ secrets.HEIMGEWEBE_AUTOBOT_TOKEN }}
+        with:
+          github-token: ${{ env.AUTOBOT_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = 'command-payload.json';
+            const payload = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+            const targetRepo = payload.target_repo;
+            if (!targetRepo) {
+              core.info('Kein target_repo gefunden – breche ab.');
+              return;
+            }
+
+            core.info(`Sende repository_dispatch an heimgewebe/${targetRepo} ...`);
+
+            await github.rest.repos.createDispatchEvent({
+              owner: 'heimgewebe',
+              repo: targetRepo,
+              event_type: 'heimgewebe-command',
+              client_payload: payload,
+            });
+
+            core.info('repository_dispatch gesendet.');


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that watches PR comments for @heimgewebe/ commands
- parse comment payloads and forward them to the specified heimgewebe repository via repository_dispatch

## Testing
- not run (workflow change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dd224a4c832c935a87d1bd3c3f5d)