### PR TITLE
docs: update context with Plexer role

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -11,3 +11,19 @@ Er nutzt:
 - sichter → Analyse und Muster
 - wgx → Guard/Smoke
 - hausKI → orchestrierte Aktionen
+
+## Plexer als Event-Eintrittspunkt
+
+Events sollten Heimgeist nicht mehr direkt aus Workflows erreichen,
+sondern über Plexer:
+
+- Plexer nimmt Events von allen Repos entgegen
+- prüft Minimalstruktur (type, source, payload)
+- loggt und routet die Events an Heimgeist weiter
+
+Heimgeist bleibt damit fokussiert auf:
+
+- Interpretation (Risiko, Muster, Empfehlungen)
+- Lernen aus Ereignissen über Zeit
+
+und überlässt Plexer den Transport.


### PR DESCRIPTION
Updates `docs/context.md` to define Plexer (formerly Heimplex) as the new primary event entry point for the Heimgewebe organism. Plexer handles transport, logging, and routing, while Heimgeist focuses on interpretation and risk analysis.