### PR TITLE
Make configuration retrieval defensive

### DIFF
--- a/src/core/heimgeist.test.ts
+++ b/src/core/heimgeist.test.ts
@@ -54,6 +54,18 @@ describe('Heimgeist', () => {
       heimgeist.setAutonomyLevel(AutonomyLevel.Passive);
       expect(heimgeist.getConfig().autonomyLevel).toBe(AutonomyLevel.Passive);
     });
+
+    it('should protect internal configuration from external mutation', () => {
+      const config = heimgeist.getConfig();
+
+      config.activeRoles.push(HeimgeistRole.Observer);
+      config.policies[0].name = 'mutated-policy';
+
+      const freshConfig = heimgeist.getConfig();
+
+      expect(freshConfig.activeRoles.length).toBe(4);
+      expect(freshConfig.policies[0].name).not.toBe('mutated-policy');
+    });
   });
 
   describe('event processing', () => {

--- a/src/core/heimgeist.ts
+++ b/src/core/heimgeist.ts
@@ -591,7 +591,17 @@ export class Heimgeist {
    * Get current configuration
    */
   getConfig(): HeimgeistConfig {
-    return { ...this.config };
+    return {
+      autonomyLevel: this.config.autonomyLevel,
+      activeRoles: [...this.config.activeRoles],
+      policies: this.config.policies.map((policy) => ({
+        ...policy,
+        allowedActions: [...policy.allowedActions],
+        conditions: policy.conditions ? { ...policy.conditions } : undefined,
+      })),
+      eventSources: this.config.eventSources.map((source) => ({ ...source })),
+      outputs: this.config.outputs.map((output) => ({ ...output })),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
- return a defensive deep copy from `getConfig` to prevent external mutations from leaking into Heimgeist state
- add coverage ensuring configuration callers cannot alter internal arrays or policies

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9988f1b0832ca45bc53729491cbe)