### PR TITLE
Respect persistenceEnabled config override

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -20,6 +20,7 @@ describe('config', () => {
       expect(config.activeRoles).toContain(HeimgeistRole.Director);
       expect(config.activeRoles).toContain(HeimgeistRole.Archivist);
       expect(config.policies.length).toBeGreaterThan(0);
+      expect(config.persistenceEnabled).toBe(true);
     });
   });
 
@@ -41,12 +42,14 @@ autonomyLevel: 3
 activeRoles:
   - observer
   - critic
+persistenceEnabled: false
 `);
 
       const config = loadConfig('/some/path');
 
       expect(config.autonomyLevel).toBe(3);
       expect(config.activeRoles).toEqual(['observer', 'critic']);
+      expect(config.persistenceEnabled).toBe(false);
     });
 
     it('should fallback to default on parse error', () => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -106,6 +106,11 @@ function mergeConfig(
       override.eventSources !== undefined ? override.eventSources : defaults.eventSources,
     // Replace outputs completely if provided (don't merge with defaults)
     outputs: override.outputs !== undefined ? override.outputs : defaults.outputs,
+    // Respect persistence toggle from override while defaulting to provided value
+    persistenceEnabled:
+      override.persistenceEnabled !== undefined
+        ? override.persistenceEnabled
+        : defaults.persistenceEnabled,
   };
 }
 
@@ -119,6 +124,7 @@ export function getDefaultConfig(): HeimgeistConfig {
     policies: DEFAULT_CONFIG.policies.map((p) => ({ ...p })),
     eventSources: DEFAULT_CONFIG.eventSources.map((e) => ({ ...e })),
     outputs: DEFAULT_CONFIG.outputs.map((o) => ({ ...o })),
+    persistenceEnabled: DEFAULT_CONFIG.persistenceEnabled,
   };
 }
 


### PR DESCRIPTION
## Summary
- preserve the persistenceEnabled flag when loading and generating Heimgeist configs
- extend configuration tests to assert default persistence and override handling

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391da4d998832c92de256faa749b08)