### PR TITLE
Fix ESLint globals and observatory parsing safety

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,10 @@ export default [
         module: 'readonly',
         require: 'readonly',
         exports: 'readonly',
+        fetch: 'readonly',
+        AbortController: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
       },
     },
     plugins: {

--- a/src/core/heimgeist.ts
+++ b/src/core/heimgeist.ts
@@ -232,8 +232,12 @@ export class Heimgeist {
                 return insights;
               }
 
-              const observatoryData = JSON.parse(rawText) as any;
-              const generatedAt = observatoryData.generated_at || 'unknown';
+              const observatoryData = JSON.parse(rawText) as Record<string, unknown>;
+              const generatedAtRaw = observatoryData.generated_at;
+              const generatedAt =
+                typeof generatedAtRaw === 'string' && generatedAtRaw.length > 0
+                  ? generatedAtRaw
+                  : 'unknown';
               const summary = `Observatory data received from ${url}. Generated at ${generatedAt}.`;
 
               insights.push({


### PR DESCRIPTION
## Summary
- add Node runtime globals to ESLint configuration to avoid false no-undef errors
- tighten Knowledge Observatory parsing by validating generated_at strings before use

## Testing
- npm run lint:eslint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958cb684080832c99af96a5e2711970)