### PR TITLE
feat(core): implement state refresh and robust self-model updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,6 @@
         "ts-jest": "^29.4.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
-      },
-      "engines": {
-        "node": ">=18.17.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -73,6 +70,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1676,6 +1674,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1817,6 +1816,7 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2323,6 +2323,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2659,6 +2660,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3313,6 +3315,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3373,6 +3376,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4615,6 +4619,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5933,6 +5938,7 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6695,6 +6701,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6829,6 +6836,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6931,6 +6939,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
         "ts-jest": "^29.4.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -70,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1674,7 +1676,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1816,7 +1817,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2323,7 +2323,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2660,7 +2659,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3315,7 +3313,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3376,7 +3373,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4619,7 +4615,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5938,7 +5933,6 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6701,7 +6695,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6836,7 +6829,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6939,7 +6931,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -53,13 +53,19 @@ export class HeimgeistCoreLoop {
 
   async tick() {
     // 0. Meta-Cognitive Update
+    // Refresh state from disk to pick up external changes (e.g. manual approvals)
+    this.heimgeist.refreshState();
+
     // Fetch signals (mocked for now, in real impl would come from HausKI/Metrics)
     // "vor Analyse: self_model.update(signals)"
+    const mem = process.memoryUsage();
+    const heapUsedPct = Math.round((mem.heapUsed / mem.heapTotal) * 100);
+
     const mockSignals = {
-        // Simple mock: stable load to prevent self-state noise
-        cpu_load: 20,
-        memory_pressure: 40,
-        // We could calculate failure rate from heimgeist stats if exposed
+      // Simple mock: stable load to prevent self-state noise
+      cpu_load: 20,
+      memory_pressure: heapUsedPct,
+      // We could calculate failure rate from heimgeist stats if exposed
     };
     this.heimgeist.updateSelfModel(mockSignals);
 

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -12,6 +12,8 @@ import { defaultLogger, Logger } from './logger';
 // though it is preferred to import from types
 export { ChronikClient };
 
+const REFRESH_THROTTLE_MS = 5000;
+
 export class HeimgeistCoreLoop {
   private running = false;
   private chronik: ChronikClient;
@@ -56,7 +58,7 @@ export class HeimgeistCoreLoop {
     // 0. Meta-Cognitive Update
     // Refresh state from disk to pick up external changes (e.g. manual approvals)
     // Throttled to avoid excessive I/O (max every 5s)
-    if (Date.now() - this.lastRefresh > 5000) {
+    if (Date.now() - this.lastRefresh > REFRESH_THROTTLE_MS) {
       this.heimgeist.refreshState();
       this.lastRefresh = Date.now();
     }

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -17,6 +17,7 @@ export class HeimgeistCoreLoop {
   private chronik: ChronikClient;
   private heimgeist: Heimgeist;
   private logger: Logger;
+  private lastRefresh = 0;
 
   constructor(chronik: ChronikClient, autonomyLevel: AutonomyLevel = AutonomyLevel.Warning) {
     this.chronik = chronik;
@@ -54,7 +55,11 @@ export class HeimgeistCoreLoop {
   async tick() {
     // 0. Meta-Cognitive Update
     // Refresh state from disk to pick up external changes (e.g. manual approvals)
-    this.heimgeist.refreshState();
+    // Throttled to avoid excessive I/O (max every 5s)
+    if (Date.now() - this.lastRefresh > 5000) {
+      this.heimgeist.refreshState();
+      this.lastRefresh = Date.now();
+    }
 
     // Fetch signals (mocked for now, in real impl would come from HausKI/Metrics)
     // "vor Analyse: self_model.update(signals)"

--- a/src/core/self_model.ts
+++ b/src/core/self_model.ts
@@ -146,13 +146,6 @@ export class SelfModel {
    * Determine autonomy level based on internal state
    * "Regel: hohe risk_tension + niedrige confidence ⇒ Wechsel zu critical"
    * "Hysterese verpflichtend (kein Flip-Flop)"
-   *
-   * Dormant semantics: 'dormant' is a manual-override state.
-   * Safety-escape transitions (→ 'critical') are always allowed regardless of dormant,
-   * so the system can still escalate in emergencies.
-   * Optimization/activity transitions (→ 'aware', fallback defaults) are blocked from
-   * 'dormant' and require an explicit manual wake-up.
-   * Fatigue-driven rest (→ 'reflective') is also allowed from 'dormant' as a safety measure.
    */
   private updateAutonomyLevel(): void {
     const current = this.state.autonomy_level;

--- a/src/core/self_model.ts
+++ b/src/core/self_model.ts
@@ -50,6 +50,12 @@ export class SelfModel {
   public update(signals: SystemSignals): boolean {
     const basis_signals: string[] = [];
 
+    // Preserve manual signals
+    if (this.state.basis_signals && Array.isArray(this.state.basis_signals)) {
+      const manualSignals = this.state.basis_signals.filter((s) => s.startsWith('Manual'));
+      basis_signals.push(...manualSignals);
+    }
+
     // 1. Calculate Fatigue
     // Heuristic: High CPU/Memory or many open actions causes fatigue
     let fatigue = 0.0;
@@ -163,7 +169,10 @@ export class SelfModel {
         next = 'reflective'; // "Sit back and think"
     }
     else if (this.state.confidence > 0.8 && this.state.risk_tension < 0.3) {
+      // Only promote to aware if we are not dormant (requires manual wake-up)
+      if (current !== 'dormant') {
         next = 'aware'; // "Alert and ready"
+      }
     }
     // Default fallback if not dormant
     else if (current !== 'dormant') {

--- a/src/core/self_model.ts
+++ b/src/core/self_model.ts
@@ -146,6 +146,13 @@ export class SelfModel {
    * Determine autonomy level based on internal state
    * "Regel: hohe risk_tension + niedrige confidence ⇒ Wechsel zu critical"
    * "Hysterese verpflichtend (kein Flip-Flop)"
+   *
+   * Dormant semantics: 'dormant' is a manual-override state.
+   * Safety-escape transitions (→ 'critical') are always allowed regardless of dormant,
+   * so the system can still escalate in emergencies.
+   * Optimization/activity transitions (→ 'aware', fallback defaults) are blocked from
+   * 'dormant' and require an explicit manual wake-up.
+   * Fatigue-driven rest (→ 'reflective') is also allowed from 'dormant' as a safety measure.
    */
   private updateAutonomyLevel(): void {
     const current = this.state.autonomy_level;

--- a/src/core/self_model.ts
+++ b/src/core/self_model.ts
@@ -11,6 +11,7 @@ export class SelfModel {
   private readonly CONFIDENCE_THRESHOLD = 0.35;
   private readonly RISK_TENSION_THRESHOLD = 0.6;
   private readonly MAX_BASIS_SIGNALS = 50;
+  private readonly MANUAL_SIGNAL_PREFIX = 'Manual';
 
   constructor(initialState?: SelfModelState) {
     this.store = new SelfStateStore();
@@ -52,7 +53,9 @@ export class SelfModel {
 
     // Preserve manual signals
     if (this.state.basis_signals && Array.isArray(this.state.basis_signals)) {
-      const manualSignals = this.state.basis_signals.filter((s) => s.startsWith('Manual'));
+      const manualSignals = this.state.basis_signals.filter((s) =>
+        s.startsWith(this.MANUAL_SIGNAL_PREFIX)
+      );
       basis_signals.push(...manualSignals);
     }
 

--- a/tests/heimgeist_refresh.test.ts
+++ b/tests/heimgeist_refresh.test.ts
@@ -1,0 +1,85 @@
+import { Heimgeist, createHeimgeist } from '../src/core/heimgeist';
+import { PlannedAction, RiskSeverity, HeimgeistRole } from '../src/types';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Mock fs and config
+jest.mock('fs');
+jest.mock('../src/config/state-paths', () => ({
+  ACTIONS_DIR: '/mock/actions',
+  INSIGHTS_DIR: '/mock/insights',
+  ARTIFACTS_DIR: '/mock/artifacts',
+  STATE_DIR: '/mock/state',
+}));
+
+describe('Heimgeist.refreshState', () => {
+  let heimgeist: Heimgeist;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
+
+    // Create instance (will call loadState -> refreshState)
+    heimgeist = createHeimgeist({
+        autonomyLevel: 2,
+        activeRoles: [HeimgeistRole.Director],
+        policies: [],
+        eventSources: [],
+        outputs: [],
+        persistenceEnabled: true
+    });
+  });
+
+  it('should reload actions from disk', () => {
+      const actionId = 'action-123';
+      const mockAction: PlannedAction = {
+          id: actionId,
+          timestamp: new Date(),
+          trigger: {
+              id: 'trigger-1',
+              timestamp: new Date(),
+              role: HeimgeistRole.Critic,
+              type: 'risk',
+              severity: RiskSeverity.Medium,
+              title: 'Test Risk',
+              description: 'Test'
+          },
+          steps: [],
+          requiresConfirmation: true,
+          status: 'pending'
+      };
+
+      // 1. Initial state: action not present (or added then modified)
+      // Let's simulate that readFileSync returns a modified action
+      const updatedAction = { ...mockAction, status: 'approved' };
+
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.readdirSync as jest.Mock).mockReturnValue(['action-123.json']);
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(updatedAction));
+
+      // 2. Call refreshState
+      heimgeist.refreshState();
+
+      // 3. Verify internal state
+      const actions = heimgeist.getPlannedActions();
+      expect(actions).toHaveLength(1);
+      expect(actions[0].id).toBe(actionId);
+      expect(actions[0].status).toBe('approved');
+  });
+
+  it('should handle missing directories gracefully', () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      expect(() => heimgeist.refreshState()).not.toThrow();
+  });
+
+  it('should handle JSON parse errors gracefully', () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.readdirSync as jest.Mock).mockReturnValue(['bad.json']);
+      (fs.readFileSync as jest.Mock).mockReturnValue('invalid json');
+
+      // Should not throw, just log warning
+      expect(() => heimgeist.refreshState()).not.toThrow();
+  });
+});

--- a/tests/heimgeist_refresh.test.ts
+++ b/tests/heimgeist_refresh.test.ts
@@ -1,4 +1,4 @@
-import { Heimgeist, createHeimgeist } from '../src/core/heimgeist';
+import { createHeimgeist, type Heimgeist } from '../src/core/heimgeist';
 import { PlannedAction, RiskSeverity, HeimgeistRole } from '../src/types';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/tests/heimgeist_refresh.test.ts
+++ b/tests/heimgeist_refresh.test.ts
@@ -1,6 +1,7 @@
 import { Heimgeist, createHeimgeist } from '../src/core/heimgeist';
 import { PlannedAction, RiskSeverity, HeimgeistRole } from '../src/types';
 import * as fs from 'fs';
+import * as path from 'path';
 import { ACTIONS_DIR, INSIGHTS_DIR } from '../src/config/state-paths';
 
 // Mock fs and config
@@ -64,9 +65,11 @@ describe('Heimgeist.refreshState', () => {
           return [];
       });
 
-      // Mock readFile to return the content
+      // Mock readFile to return the content with strict path matching
       (fs.readFileSync as jest.Mock).mockImplementation((p: string) => {
-          if (p.includes(actionId)) return JSON.stringify(mockAction);
+          if (p === path.join(ACTIONS_DIR, 'action-123.json')) {
+              return JSON.stringify(mockAction);
+          }
           return '{}';
       });
 
@@ -92,7 +95,9 @@ describe('Heimgeist.refreshState', () => {
           return [];
       });
       (fs.readFileSync as jest.Mock).mockImplementation((p: string) => {
-          if (p.includes(actionId)) return JSON.stringify(mockAction);
+          if (p === path.join(ACTIONS_DIR, `${actionId}.json`)) {
+              return JSON.stringify(mockAction);
+          }
           return '{}';
       });
 
@@ -125,7 +130,7 @@ describe('Heimgeist.refreshState', () => {
           return [];
       });
       (fs.readFileSync as jest.Mock).mockImplementation((p: string) => {
-          if (p.includes('bad.json')) return 'invalid json';
+          if (p === path.join(ACTIONS_DIR, 'bad.json')) return 'invalid json';
           return '{}';
       });
 


### PR DESCRIPTION
This PR implements a mechanism for the running Heimgeist process to refresh its state from disk, enabling it to detect when actions have been approved or modified by external tools (e.g., CLI). It also improves the robustness of the Self-Model by preventing automatic state transitions from 'dormant' and preserving manual override signals in the basis signals list. Additionally, the core loop now uses real process memory usage for fatigue calculation.

---
*PR created automatically by Jules for task [16856987313773612022](https://jules.google.com/task/16856987313773612022) started by @alexdermohr*