### PR TITLE
security: fix full configuration disclosure vulnerability

### DIFF
--- a/src/core/heimgeist.ts
+++ b/src/core/heimgeist.ts
@@ -1623,7 +1623,7 @@ export class Heimgeist {
    * Get current configuration
    */
   getConfig(): HeimgeistConfig {
-    return {
+    const config = {
       autonomyLevel: this.config.autonomyLevel,
       activeRoles: [...this.config.activeRoles],
       policies: this.config.policies.map((policy) => ({
@@ -1634,6 +1634,7 @@ export class Heimgeist {
       eventSources: this.config.eventSources.map((source) => ({ ...source })),
       outputs: this.config.outputs.map((output) => ({ ...output })),
     };
+    return this.sanitizePayload(config);
   }
 
   /**

--- a/tests/security_reproduction.test.ts
+++ b/tests/security_reproduction.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import { createApp } from '../src/api/server';
+import { Heimgeist } from '../src/core';
+import { AutonomyLevel, HeimgeistRole } from '../src/types';
+
+describe('Heimgeist Configuration Disclosure Vulnerability', () => {
+  it('should redact sensitive information in the config endpoint', async () => {
+    const heimgeist = new Heimgeist({
+      autonomyLevel: AutonomyLevel.Warning,
+      activeRoles: [HeimgeistRole.Observer],
+      policies: [],
+      eventSources: [
+        {
+          name: 'sensitive-source',
+          type: 'chronik',
+          config: {
+            token: 'secret-token-123',
+            api_key: 'sensitive-api-key',
+          },
+          enabled: true,
+        },
+      ],
+      outputs: [
+        {
+          name: 'sensitive-output',
+          type: 'webhook',
+          config: {
+            url: 'https://hooks.slack.com/services/T0000/B0000/XXXX',
+            secret: 'webhook-secret',
+          },
+          enabled: true,
+        },
+      ],
+      persistenceEnabled: false,
+    });
+    const app = createApp(heimgeist);
+
+    const response = await request(app).get('/heimgeist/config');
+
+    expect(response.status).toBe(200);
+
+    // Check eventSources
+    const source = response.body.eventSources.find((s: any) => s.name === 'sensitive-source');
+    expect(source.config.token).toBe('[REDACTED]');
+    expect(source.config.api_key).toBe('[REDACTED]');
+
+    // Check outputs
+    const output = response.body.outputs.find((o: any) => o.name === 'sensitive-output');
+    expect(output.config.secret).toBe('[REDACTED]');
+  });
+});

--- a/tests/security_reproduction.test.ts
+++ b/tests/security_reproduction.test.ts
@@ -41,11 +41,15 @@ describe('Heimgeist Configuration Disclosure Vulnerability', () => {
 
     // Check eventSources
     const source = response.body.eventSources.find((s: any) => s.name === 'sensitive-source');
+    expect(source).toBeTruthy();
     expect(source.config.token).toBe('[REDACTED]');
     expect(source.config.api_key).toBe('[REDACTED]');
 
     // Check outputs
     const output = response.body.outputs.find((o: any) => o.name === 'sensitive-output');
+    expect(output).toBeTruthy();
+    expect(output.name).toBe('sensitive-output');
     expect(output.config.secret).toBe('[REDACTED]');
+    expect(output.config.url).toBe('https://hooks.slack.com/services/T0000/B0000/XXXX');
   });
 });


### PR DESCRIPTION
Updated `Heimgeist.getConfig()` to use `sanitizePayload()` to redact sensitive fields (tokens, secrets, API keys) before returning the configuration. This prevents accidental exposure of credentials through the `/heimgeist/config` API endpoint.

Added a reproduction test case to verify redaction of sensitive fields.