### PR TITLE
Refactor SelfModel persistence to be asynchronous

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,6 @@
         "ts-jest": "^29.4.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
-      },
-      "engines": {
-        "node": ">=18.17.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -73,6 +70,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1676,6 +1674,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1817,6 +1816,7 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2323,6 +2323,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2659,6 +2660,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3313,6 +3315,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3373,6 +3376,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4615,6 +4619,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5933,6 +5938,7 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6695,6 +6701,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6829,6 +6836,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6931,6 +6939,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
         "ts-jest": "^29.4.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -70,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1674,7 +1676,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1816,7 +1817,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2323,7 +2323,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2660,7 +2659,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3315,7 +3313,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3376,7 +3373,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4619,7 +4615,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5938,7 +5933,6 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6701,7 +6695,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6836,7 +6829,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6939,7 +6931,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/core/heimgeist-critical.test.ts
+++ b/src/core/heimgeist-critical.test.ts
@@ -5,7 +5,18 @@ import { defaultLogger } from './logger';
 import * as fs from 'fs';
 
 // Mock fs to avoid writing to disk during tests
-jest.mock('fs');
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  readdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  promises: {
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    unlink: jest.fn().mockResolvedValue(undefined),
+    readdir: jest.fn().mockResolvedValue([]),
+  }
+}));
 jest.mock('timers/promises', () => ({
   setTimeout: jest.fn().mockResolvedValue(undefined),
 }));
@@ -75,7 +86,7 @@ describe('Heimgeist Critical Flows', () => {
           open_actions_count: 50
       };
 
-      heimgeist.updateSelfModel(badSignals);
+      await heimgeist.updateSelfModel(badSignals);
 
       const event = {
         id: uuidv4(),

--- a/src/core/heimgeist.ts
+++ b/src/core/heimgeist.ts
@@ -218,8 +218,8 @@ export class Heimgeist {
   /**
    * Update Self-Model with system signals
    */
-  public updateSelfModel(signals: SystemSignals): void {
-      const persisted = this.selfModel.update(signals);
+  public async updateSelfModel(signals: SystemSignals): Promise<void> {
+      const persisted = await this.selfModel.update(signals);
       if (persisted) {
           this.writeSelfStateBundle();
           void this.publishSelfStateSnapshot();
@@ -1572,13 +1572,13 @@ export class Heimgeist {
           const cmd = step.parameters.command as string;
           const args = (step.parameters.args as string[]) || [];
 
-          if (cmd === 'reset') this.selfModel.reset();
+          if (cmd === 'reset') await this.selfModel.reset();
           if (cmd === 'set' && args) {
             const autonomyArg = args.find((a) => a.startsWith('autonomy='));
             if (autonomyArg) {
               const val = autonomyArg.split('=')[1].trim().toLowerCase();
               if (['dormant', 'aware', 'reflective', 'critical'].includes(val)) {
-                this.selfModel.setAutonomy(val as 'dormant' | 'aware' | 'reflective' | 'critical');
+                await this.selfModel.setAutonomy(val as 'dormant' | 'aware' | 'reflective' | 'critical');
               } else {
                 this.logger.warn(`Invalid autonomy level requested: ${val}`);
               }
@@ -1621,7 +1621,7 @@ export class Heimgeist {
         await this.saveAction(action);
 
         // Reflect success
-        this.selfModel.reflect(true);
+        await this.selfModel.reflect(true);
         this.writeSelfStateBundle();
         void this.publishSelfStateSnapshot();
 
@@ -1631,7 +1631,7 @@ export class Heimgeist {
       return false;
     } catch (error) {
       this.logger.error(`Failed to execute action ${actionId}: ${error}`);
-      this.selfModel.reflect(false); // Reflect failure
+      await this.selfModel.reflect(false); // Reflect failure
       this.writeSelfStateBundle();
       void this.publishSelfStateSnapshot();
       return false;

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -74,7 +74,7 @@ export class HeimgeistCoreLoop {
       memory_pressure: heapUsedPct,
       // We could calculate failure rate from heimgeist stats if exposed
     };
-    this.heimgeist.updateSelfModel(mockSignals);
+    await this.heimgeist.updateSelfModel(mockSignals);
 
     // 1. Pull
     const event = await this.chronik.nextEvent([

--- a/src/core/self_model.test.ts
+++ b/src/core/self_model.test.ts
@@ -3,7 +3,19 @@ import { SystemSignals } from '../types';
 import * as fs from 'fs';
 
 // Mock fs to avoid actual file writing during tests
-jest.mock('fs');
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  readdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  promises: {
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    unlink: jest.fn().mockResolvedValue(undefined),
+    readdir: jest.fn().mockResolvedValue([]),
+  }
+}));
+
 jest.mock('../config/state-paths', () => ({
   SELF_MODEL_DIR: '/mock/self_model',
 }));
@@ -12,35 +24,36 @@ describe('SelfModel', () => {
   let selfModel: SelfModel;
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
     (fs.existsSync as jest.Mock).mockReturnValue(false);
     (fs.mkdirSync as jest.Mock).mockImplementation(() => {});
     (fs.writeFileSync as jest.Mock).mockImplementation(() => {});
+    (fs.readdirSync as jest.Mock).mockReturnValue([]); // For loadLatest
 
     // Initialize fresh model
     selfModel = new SelfModel();
   });
 
   describe('update', () => {
-    it('should update fatigue based on cpu load', () => {
+    it('should update fatigue based on cpu load', async () => {
       const signals: SystemSignals = { cpu_load: 90 };
-      selfModel.update(signals);
+      await selfModel.update(signals);
       const state = selfModel.getState();
       expect(state.fatigue).toBeGreaterThan(0);
       expect(state.basis_signals).toContain('High CPU load');
     });
 
-    it('should update risk tension based on ci failure rate', () => {
+    it('should update risk tension based on ci failure rate', async () => {
       const signals: SystemSignals = { ci_failure_rate: 0.3 };
-      selfModel.update(signals);
+      await selfModel.update(signals);
       const state = selfModel.getState();
       expect(state.risk_tension).toBeGreaterThan(0);
       expect(state.basis_signals).toContain('High CI failure rate: 0.3');
     });
 
-    it('should lower confidence when error rate is high', () => {
+    it('should lower confidence when error rate is high', async () => {
       const signals: SystemSignals = { error_rate: 0.2 };
-      selfModel.update(signals);
+      await selfModel.update(signals);
       const state = selfModel.getState();
       // Confidence starts at 1.0 (minus fatigue/tension).
       // error_rate > 0.1 subtracts 0.3.
@@ -50,13 +63,13 @@ describe('SelfModel', () => {
   });
 
   describe('Autonomy Switching (Hysteresis)', () => {
-    it('should switch to critical when risk is high and confidence low', () => {
+    it('should switch to critical when risk is high and confidence low', async () => {
         // Force state to near critical
         const signals: SystemSignals = {
             risk_score: 0.7, // High tension
             error_rate: 0.5  // Lowers confidence significantly
         };
-        selfModel.update(signals);
+        await selfModel.update(signals);
 
         const state = selfModel.getState();
         expect(state.risk_tension).toBeGreaterThan(0.6);
@@ -64,30 +77,30 @@ describe('SelfModel', () => {
         expect(state.autonomy_level).toBe('critical');
     });
 
-    it('should NOT switch back from critical immediately (hysteresis)', () => {
+    it('should NOT switch back from critical immediately (hysteresis)', async () => {
         // First get to critical
         let signals: SystemSignals = { risk_score: 0.8, error_rate: 0.5 };
-        selfModel.update(signals);
+        await selfModel.update(signals);
         expect(selfModel.getState().autonomy_level).toBe('critical');
 
         // Now improve conditions slightly, but not enough to exit critical
         // Recovery requires risk < 0.4 and confidence > 0.6
         signals = { risk_score: 0.5, error_rate: 0.0 }; // Risk 0.5 is still >= 0.4
-        selfModel.update(signals);
+        await selfModel.update(signals);
 
         expect(selfModel.getState().autonomy_level).toBe('critical');
     });
 
-    it('should switch back from critical when conditions are very good', () => {
+    it('should switch back from critical when conditions are very good', async () => {
         // First get to critical
         let signals: SystemSignals = { risk_score: 0.8, error_rate: 0.5 };
-        selfModel.update(signals);
+        await selfModel.update(signals);
         expect(selfModel.getState().autonomy_level).toBe('critical');
 
         // Now improve conditions significantly
         // Recovery requires risk < 0.4 and confidence > 0.6
         signals = { risk_score: 0.1, error_rate: 0.0 };
-        selfModel.update(signals);
+        await selfModel.update(signals);
 
         const state = selfModel.getState();
         expect(state.autonomy_level).toBe('reflective'); // As per logic: critical -> reflective
@@ -95,34 +108,34 @@ describe('SelfModel', () => {
   });
 
   describe('reflect', () => {
-      it('should increase confidence on success', () => {
+      it('should increase confidence on success', async () => {
           // Establish baseline with some fatigue/risk so confidence isn't maxed out (1.0)
-          selfModel.update({ cpu_load: 85 });
+          await selfModel.update({ cpu_load: 85 });
           const startConfidence = selfModel.getState().confidence;
           // Ensure we start below 1.0
           expect(startConfidence).toBeLessThan(1.0);
 
-          selfModel.reflect(true);
+          await selfModel.reflect(true);
           expect(selfModel.getState().confidence).toBeGreaterThan(startConfidence);
       });
 
-      it('should decrease confidence on failure', () => {
-          selfModel.update({ cpu_load: 50 });
+      it('should decrease confidence on failure', async () => {
+          await selfModel.update({ cpu_load: 50 });
           const startConfidence = selfModel.getState().confidence;
 
-          selfModel.reflect(false);
+          await selfModel.reflect(false);
           expect(selfModel.getState().confidence).toBeLessThan(startConfidence);
       });
   });
 
   describe('Safety Gate', () => {
-      it('should return safe when metrics are good', () => {
-          selfModel.update({}); // Defaults to good
+      it('should return safe when metrics are good', async () => {
+          await selfModel.update({}); // Defaults to good
           expect(selfModel.checkSafetyGate().safe).toBe(true);
       });
 
-      it('should block when fatigue is high', () => {
-          selfModel.update({ cpu_load: 90, memory_pressure: 90, open_actions_count: 20 });
+      it('should block when fatigue is high', async () => {
+          await selfModel.update({ cpu_load: 90, memory_pressure: 90, open_actions_count: 20 });
           // Fatigue should be ~0.8
           expect(selfModel.checkSafetyGate().safe).toBe(false);
           expect(selfModel.checkSafetyGate().reason).toContain('Fatigue');

--- a/src/core/self_model.ts
+++ b/src/core/self_model.ts
@@ -48,7 +48,7 @@ export class SelfModel {
    * Returns true if state was persisted (changed significantly or timeout), false otherwise.
    * Implements: "Initiale Ableitung (heuristisch, explizit): CI-Fehlerquote, Anzahl offener Actions..."
    */
-  public update(signals: SystemSignals): boolean {
+  public async update(signals: SystemSignals): Promise<boolean> {
     const basis_signals: string[] = [];
 
     // Preserve manual signals
@@ -136,7 +136,7 @@ export class SelfModel {
     }
 
     if (shouldPersist) {
-        this.store.save(this.state);
+        await this.store.save(this.state);
         // Deep copy state for next comparison
         this.lastPersistedState = JSON.parse(JSON.stringify(this.state));
         return true;
@@ -195,7 +195,7 @@ export class SelfModel {
    * Reflect on action outcomes to adjust self-model
    * "nach Aktion: self_model.reflect(outcome)"
    */
-  public reflect(success: boolean): void {
+  public async reflect(success: boolean): Promise<void> {
       if (success) {
           // Success boosts confidence slightly, reduces fatigue slightly?
           this.state.confidence = Math.min(1.0, this.state.confidence + 0.05);
@@ -207,7 +207,7 @@ export class SelfModel {
       }
       this.state.last_updated = new Date().toISOString();
       this.updateAutonomyLevel();
-      this.store.save(this.state);
+      await this.store.save(this.state);
   }
 
   /**
@@ -228,7 +228,7 @@ export class SelfModel {
   /**
    * Manual override or command-based reset
    */
-  public reset(): void {
+  public async reset(): Promise<void> {
       this.state = {
         confidence: 1.0,
         fatigue: 0.0,
@@ -238,17 +238,17 @@ export class SelfModel {
         basis_signals: []
       };
       this.addBasisSignal('Manual Reset');
-      this.store.save(this.state);
+      await this.store.save(this.state);
   }
 
   /**
    * Manual set
    */
-  public setAutonomy(level: 'dormant' | 'aware' | 'reflective' | 'critical'): void {
+  public async setAutonomy(level: 'dormant' | 'aware' | 'reflective' | 'critical'): Promise<void> {
       this.state.autonomy_level = level;
       this.addBasisSignal(`Manual override to ${level}`);
       this.state.last_updated = new Date().toISOString();
-      this.store.save(this.state);
+      await this.store.save(this.state);
   }
 
   /**

--- a/src/core/self_state_store.test.ts
+++ b/src/core/self_state_store.test.ts
@@ -3,7 +3,19 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SELF_MODEL_DIR } from '../config/state-paths';
 
-jest.mock('fs');
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  readdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  promises: {
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    unlink: jest.fn().mockResolvedValue(undefined),
+    readdir: jest.fn().mockResolvedValue([]),
+  }
+}));
+
 jest.mock('../config/state-paths', () => ({
   SELF_MODEL_DIR: '/mock/self_model',
 }));
@@ -12,34 +24,34 @@ describe('SelfStateStore Retention', () => {
   let store: SelfStateStore;
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
     (fs.existsSync as jest.Mock).mockReturnValue(true);
     store = new SelfStateStore();
   });
 
-  it('should cleanup old snapshots when limit is exceeded', () => {
+  it('should cleanup old snapshots when limit is exceeded', async () => {
     // Mock readdir to return 60 files
     const mockFiles = Array.from({ length: 60 }, (_, i) =>
         `snapshot-2023-01-01T12:${i < 10 ? '0' + i : i}:00.000Z.json`
     ).reverse(); // Newest first
 
-    (fs.readdirSync as jest.Mock).mockReturnValue(mockFiles);
+    (fs.promises.readdir as jest.Mock).mockResolvedValue(mockFiles);
 
-    store.cleanup(50);
+    await store.cleanup(50);
 
     // Should delete 10 files (60 - 50)
-    expect(fs.unlinkSync).toHaveBeenCalledTimes(10);
+    expect(fs.promises.unlink).toHaveBeenCalledTimes(10);
     // Should delete the oldest ones (end of the sorted list)
-    expect(fs.unlinkSync).toHaveBeenCalledWith(path.join(SELF_MODEL_DIR, mockFiles[50]));
-    expect(fs.unlinkSync).toHaveBeenCalledWith(path.join(SELF_MODEL_DIR, mockFiles[59]));
+    expect(fs.promises.unlink).toHaveBeenCalledWith(path.join(SELF_MODEL_DIR, mockFiles[50]));
+    expect(fs.promises.unlink).toHaveBeenCalledWith(path.join(SELF_MODEL_DIR, mockFiles[59]));
   });
 
-  it('should not delete anything if count is within limit', () => {
+  it('should not delete anything if count is within limit', async () => {
     const mockFiles = ['snapshot-1.json', 'snapshot-2.json'];
-    (fs.readdirSync as jest.Mock).mockReturnValue(mockFiles);
+    (fs.promises.readdir as jest.Mock).mockResolvedValue(mockFiles);
 
-    store.cleanup(50);
+    await store.cleanup(50);
 
-    expect(fs.unlinkSync).not.toHaveBeenCalled();
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
   });
 });

--- a/tests/self_state_store.test.ts
+++ b/tests/self_state_store.test.ts
@@ -19,7 +19,7 @@ jest.mock('fs', () => ({
 }));
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
-// Use type assertion to properly type the promises mock without `unknown` cast
+// Use type assertion to properly type the promises mock
 const mockedFsPromises = fs.promises as jest.Mocked<typeof fs.promises>;
 
 describe('SelfStateStore', () => {
@@ -83,6 +83,7 @@ describe('SelfStateStore', () => {
         'snapshot-2023-01-02T12-00-00.000Z.json',
       ];
       // Mock async readdir for cleanup
+      // Using 'as any' here sparingly because TypeScript might complain about Dir vs string[] mismatch in mock return types depending on env
       mockedFsPromises.readdir.mockResolvedValue(mockFiles as any);
 
       await store.cleanup(2);

--- a/tests/self_state_store.test.ts
+++ b/tests/self_state_store.test.ts
@@ -19,7 +19,7 @@ jest.mock('fs', () => ({
 }));
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
-// Need to cast promises to jest.Mocked manually or use ts-jest utils, but casting works for now
+// Type assertion for cleaner usage
 const mockedFsPromises = fs.promises as unknown as {
   writeFile: jest.Mock;
   unlink: jest.Mock;
@@ -40,7 +40,9 @@ describe('SelfStateStore', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockedFs.existsSync.mockReturnValue(true);
+    // Sync readdir/readFile are used in constructor/loadLatest (sync init)
     mockedFs.readdirSync.mockReturnValue([] as any);
+    // Async readdir is used in cleanup (async)
     mockedFsPromises.readdir.mockResolvedValue([]);
     store = new SelfStateStore();
   });
@@ -84,7 +86,7 @@ describe('SelfStateStore', () => {
         'snapshot-2023-01-01T12-00-00.000Z.json',
         'snapshot-2023-01-02T12-00-00.000Z.json',
       ];
-      // Mock both sync and async readdir, though cleanup uses async now
+      // Mock async readdir for cleanup
       mockedFsPromises.readdir.mockResolvedValue(mockFiles);
 
       await store.cleanup(2);

--- a/tests/self_state_store.test.ts
+++ b/tests/self_state_store.test.ts
@@ -19,12 +19,8 @@ jest.mock('fs', () => ({
 }));
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
-// Type assertion for cleaner usage
-const mockedFsPromises = fs.promises as unknown as {
-  writeFile: jest.Mock;
-  unlink: jest.Mock;
-  readdir: jest.Mock;
-};
+// Use type assertion to properly type the promises mock without `unknown` cast
+const mockedFsPromises = fs.promises as jest.Mocked<typeof fs.promises>;
 
 describe('SelfStateStore', () => {
   let store: SelfStateStore;
@@ -87,7 +83,7 @@ describe('SelfStateStore', () => {
         'snapshot-2023-01-02T12-00-00.000Z.json',
       ];
       // Mock async readdir for cleanup
-      mockedFsPromises.readdir.mockResolvedValue(mockFiles);
+      mockedFsPromises.readdir.mockResolvedValue(mockFiles as any);
 
       await store.cleanup(2);
 
@@ -105,7 +101,7 @@ describe('SelfStateStore', () => {
       const mockFiles = [
         'snapshot-2023-01-01T12-00-00.000Z.json',
       ];
-      mockedFsPromises.readdir.mockResolvedValue(mockFiles);
+      mockedFsPromises.readdir.mockResolvedValue(mockFiles as any);
 
       await store.cleanup(50);
       expect(mockedFsPromises.unlink).not.toHaveBeenCalled();

--- a/tests/self_state_store.test.ts
+++ b/tests/self_state_store.test.ts
@@ -3,8 +3,28 @@ import { SelfModelState } from '../src/types';
 import * as fs from 'fs';
 import { SELF_MODEL_DIR } from '../src/config/state-paths';
 
-jest.mock('fs');
+// Mock both synchronous and async fs methods
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  readdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  unlinkSync: jest.fn(),
+  promises: {
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    unlink: jest.fn().mockResolvedValue(undefined),
+    readdir: jest.fn().mockResolvedValue([]),
+  }
+}));
+
 const mockedFs = fs as jest.Mocked<typeof fs>;
+// Need to cast promises to jest.Mocked manually or use ts-jest utils, but casting works for now
+const mockedFsPromises = fs.promises as unknown as {
+  writeFile: jest.Mock;
+  unlink: jest.Mock;
+  readdir: jest.Mock;
+};
 
 describe('SelfStateStore', () => {
   let store: SelfStateStore;
@@ -21,38 +41,36 @@ describe('SelfStateStore', () => {
     jest.resetAllMocks();
     mockedFs.existsSync.mockReturnValue(true);
     mockedFs.readdirSync.mockReturnValue([] as any);
+    mockedFsPromises.readdir.mockResolvedValue([]);
     store = new SelfStateStore();
   });
 
   describe('save', () => {
-    it('should write a snapshot file with correct content', () => {
-      const writeSpy = mockedFs.writeFileSync;
-      store.save(mockState);
+    it('should write a snapshot file with correct content', async () => {
+      await store.save(mockState);
 
-      expect(writeSpy).toHaveBeenCalledWith(
+      expect(mockedFsPromises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining(SELF_MODEL_DIR),
         expect.stringContaining('"confidence": 0.8')
       );
-      expect(writeSpy).toHaveBeenCalledWith(
+      expect(mockedFsPromises.writeFile).toHaveBeenCalledWith(
         expect.stringMatching(/snapshot-.*\.json/),
         expect.any(String)
       );
     });
 
-    it('should trigger cleanup after saving', () => {
-      const cleanupSpy = jest.spyOn(store, 'cleanup').mockImplementation(() => {});
-      store.save(mockState);
+    it('should trigger cleanup after saving', async () => {
+      const cleanupSpy = jest.spyOn(store, 'cleanup').mockImplementation(() => Promise.resolve());
+      await store.save(mockState);
       expect(cleanupSpy).toHaveBeenCalledWith(50);
       cleanupSpy.mockRestore();
     });
 
-    it('should handle fs errors gracefully', () => {
-      mockedFs.writeFileSync.mockImplementation(() => {
-        throw new Error('Disk full');
-      });
+    it('should handle fs errors gracefully', async () => {
+      mockedFsPromises.writeFile.mockRejectedValue(new Error('Disk full'));
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-      expect(() => store.save(mockState)).not.toThrow();
+      await expect(store.save(mockState)).resolves.toBeUndefined();
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to persist self-state snapshot'));
 
       consoleSpy.mockRestore();
@@ -60,15 +78,16 @@ describe('SelfStateStore', () => {
   });
 
   describe('cleanup', () => {
-    it('should delete oldest files when exceeding keep limit', () => {
+    it('should delete oldest files when exceeding keep limit', async () => {
       const mockFiles = [
         'snapshot-2023-01-03T12-00-00.000Z.json',
         'snapshot-2023-01-01T12-00-00.000Z.json',
         'snapshot-2023-01-02T12-00-00.000Z.json',
       ];
-      mockedFs.readdirSync.mockReturnValue(mockFiles as any);
+      // Mock both sync and async readdir, though cleanup uses async now
+      mockedFsPromises.readdir.mockResolvedValue(mockFiles);
 
-      store.cleanup(2);
+      await store.cleanup(2);
 
       // It should sort them:
       // 2023-01-03... (newest)
@@ -76,24 +95,24 @@ describe('SelfStateStore', () => {
       // 2023-01-01... (oldest)
       // Keep 2 newest, delete 2023-01-01...
 
-      expect(mockedFs.unlinkSync).toHaveBeenCalledTimes(1);
-      expect(mockedFs.unlinkSync).toHaveBeenCalledWith(expect.stringContaining('snapshot-2023-01-01T12-00-00.000Z.json'));
+      expect(mockedFsPromises.unlink).toHaveBeenCalledTimes(1);
+      expect(mockedFsPromises.unlink).toHaveBeenCalledWith(expect.stringContaining('snapshot-2023-01-01T12-00-00.000Z.json'));
     });
 
-    it('should do nothing if count is within limit', () => {
+    it('should do nothing if count is within limit', async () => {
       const mockFiles = [
         'snapshot-2023-01-01T12-00-00.000Z.json',
       ];
-      mockedFs.readdirSync.mockReturnValue(mockFiles as any);
+      mockedFsPromises.readdir.mockResolvedValue(mockFiles);
 
-      store.cleanup(50);
-      expect(mockedFs.unlinkSync).not.toHaveBeenCalled();
+      await store.cleanup(50);
+      expect(mockedFsPromises.unlink).not.toHaveBeenCalled();
     });
 
-    it('should handle non-existent directory', () => {
+    it('should handle non-existent directory', async () => {
       mockedFs.existsSync.mockReturnValue(false);
-      expect(() => store.cleanup(50)).not.toThrow();
-      expect(mockedFs.readdirSync).not.toHaveBeenCalled();
+      await expect(store.cleanup(50)).resolves.toBeUndefined();
+      expect(mockedFsPromises.readdir).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
- `src/core/self_state_store.ts`: Converted `save` and `cleanup` to `async`.
- `src/core/self_model.ts`: Converted `update`, `reflect`, `reset`, `setAutonomy` to `async`.
- `src/core/heimgeist.ts`: Converted `updateSelfModel` to `async` and awaited `selfModel` calls.
- `src/core/loop.ts`: Awaited `heimgeist.updateSelfModel`.
- Tests updated to match new async signatures and mock `fs.promises`.

---
*PR created automatically by Jules for task [3823335976029493812](https://jules.google.com/task/3823335976029493812) started by @alexdermohr*