### PR TITLE
Refactor: Centralize fs mock in tests

### DIFF
--- a/tests/chronik-client.cursor.test.ts
+++ b/tests/chronik-client.cursor.test.ts
@@ -1,7 +1,7 @@
 import { RealChronikClient } from '../src/core/chronik-client';
 import * as fs from 'fs';
 
-jest.mock('fs', () => require('./helpers/mockFs').createMockFs());
+jest.mock('fs', () => require('./helpers/mockFs').createMockFs(jest));
 const mockedFs = fs as jest.Mocked<typeof fs>;
 
 describe('RealChronikClient Cursor Handling', () => {

--- a/tests/chronik-client.cursor.test.ts
+++ b/tests/chronik-client.cursor.test.ts
@@ -1,7 +1,7 @@
 import { RealChronikClient } from '../src/core/chronik-client';
 import * as fs from 'fs';
 
-jest.mock('fs');
+jest.mock('fs', () => require('./helpers/mockFs').createMockFs());
 const mockedFs = fs as jest.Mocked<typeof fs>;
 
 describe('RealChronikClient Cursor Handling', () => {

--- a/tests/heimgeist_refresh.test.ts
+++ b/tests/heimgeist_refresh.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { ACTIONS_DIR, INSIGHTS_DIR } from '../src/config/state-paths';
 
 // Mock fs and config
-jest.mock('fs');
+jest.mock('fs', () => require('./helpers/mockFs').createMockFs());
 jest.mock('../src/config/state-paths', () => ({
   ACTIONS_DIR: '/mock/actions',
   INSIGHTS_DIR: '/mock/insights',

--- a/tests/heimgeist_refresh.test.ts
+++ b/tests/heimgeist_refresh.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { ACTIONS_DIR, INSIGHTS_DIR } from '../src/config/state-paths';
 
 // Mock fs and config
-jest.mock('fs', () => require('./helpers/mockFs').createMockFs());
+jest.mock('fs', () => require('./helpers/mockFs').createMockFs(jest));
 jest.mock('../src/config/state-paths', () => ({
   ACTIONS_DIR: '/mock/actions',
   INSIGHTS_DIR: '/mock/insights',

--- a/tests/helpers/mockFs.ts
+++ b/tests/helpers/mockFs.ts
@@ -1,24 +1,24 @@
 // Centralized fs mock for tests
 // Covers both sync and promise-based fs methods used in the codebase
 
-export function createMockFs() {
+export function createMockFs(jestInstance: any) {
   return {
     // Sync methods
-    existsSync: jest.fn(), // Default to undefined (falsy)
-    mkdirSync: jest.fn(),
-    writeFileSync: jest.fn(),
-    readdirSync: jest.fn().mockReturnValue([]),
-    readFileSync: jest.fn().mockReturnValue(''),
-    unlinkSync: jest.fn(),
-    renameSync: jest.fn(),
+    existsSync: jestInstance.fn().mockReturnValue(false), // Explicit default false for safety
+    mkdirSync: jestInstance.fn(),
+    writeFileSync: jestInstance.fn(),
+    readdirSync: jestInstance.fn().mockReturnValue([]),
+    readFileSync: jestInstance.fn().mockReturnValue(''),
+    unlinkSync: jestInstance.fn(),
+    renameSync: jestInstance.fn(),
 
     // Promises API
     promises: {
-      writeFile: jest.fn().mockResolvedValue(undefined),
-      unlink: jest.fn().mockResolvedValue(undefined),
-      readdir: jest.fn().mockResolvedValue([]),
-      readFile: jest.fn().mockResolvedValue(''),
-      rename: jest.fn().mockResolvedValue(undefined),
+      writeFile: jestInstance.fn().mockResolvedValue(undefined),
+      unlink: jestInstance.fn().mockResolvedValue(undefined),
+      readdir: jestInstance.fn().mockResolvedValue([]),
+      readFile: jestInstance.fn().mockResolvedValue(''),
+      rename: jestInstance.fn().mockResolvedValue(undefined),
     }
   };
 }

--- a/tests/helpers/mockFs.ts
+++ b/tests/helpers/mockFs.ts
@@ -1,0 +1,24 @@
+// Centralized fs mock for tests
+// Covers both sync and promise-based fs methods used in the codebase
+
+export function createMockFs() {
+  return {
+    // Sync methods
+    existsSync: jest.fn(), // Default to undefined (falsy)
+    mkdirSync: jest.fn(),
+    writeFileSync: jest.fn(),
+    readdirSync: jest.fn().mockReturnValue([]),
+    readFileSync: jest.fn().mockReturnValue(''),
+    unlinkSync: jest.fn(),
+    renameSync: jest.fn(),
+
+    // Promises API
+    promises: {
+      writeFile: jest.fn().mockResolvedValue(undefined),
+      unlink: jest.fn().mockResolvedValue(undefined),
+      readdir: jest.fn().mockResolvedValue([]),
+      readFile: jest.fn().mockResolvedValue(''),
+      rename: jest.fn().mockResolvedValue(undefined),
+    }
+  };
+}

--- a/tests/self_state_store.test.ts
+++ b/tests/self_state_store.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import { SELF_MODEL_DIR } from '../src/config/state-paths';
 
 // Mock both synchronous and async fs methods
-jest.mock('fs', () => require('./helpers/mockFs').createMockFs());
+jest.mock('fs', () => require('./helpers/mockFs').createMockFs(jest));
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
 // Use type assertion to properly type the promises mock

--- a/tests/self_state_store.test.ts
+++ b/tests/self_state_store.test.ts
@@ -4,19 +4,7 @@ import * as fs from 'fs';
 import { SELF_MODEL_DIR } from '../src/config/state-paths';
 
 // Mock both synchronous and async fs methods
-jest.mock('fs', () => ({
-  existsSync: jest.fn(),
-  mkdirSync: jest.fn(),
-  writeFileSync: jest.fn(),
-  readdirSync: jest.fn(),
-  readFileSync: jest.fn(),
-  unlinkSync: jest.fn(),
-  promises: {
-    writeFile: jest.fn().mockResolvedValue(undefined),
-    unlink: jest.fn().mockResolvedValue(undefined),
-    readdir: jest.fn().mockResolvedValue([]),
-  }
-}));
+jest.mock('fs', () => require('./helpers/mockFs').createMockFs());
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
 // Use type assertion to properly type the promises mock


### PR DESCRIPTION
Centralized fs mock implementation to improve test maintainability.

---
*PR created automatically by Jules for task [10367384081102658037](https://jules.google.com/task/10367384081102658037) started by @alexdermohr*