### PR TITLE
🧹 [code health] remove unsafe 'as any' cast in ChronikClient

### DIFF
--- a/src/core/chronik-client.ts
+++ b/src/core/chronik-client.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { ChronikClient, ChronikEvent, HeimgeistInsightEvent, HeimgeistSelfStateSnapshotEvent } from '../types';
+import { ChronikClient, ChronikEvent, EventType, HeimgeistInsightEvent, HeimgeistSelfStateSnapshotEvent } from '../types';
 import { STATE_DIR } from '../config/state-paths';
 
 /**
@@ -83,7 +83,7 @@ export class RealChronikClient implements ChronikClient {
       }
   }
 
-  async nextEvent(types: string[]): Promise<ChronikEvent | null> {
+  async nextEvent(types: (EventType | string)[]): Promise<ChronikEvent | null> {
     // Loop limited to prevent infinite blocking, but high enough to skip sparse streams.
     // CHRONIK_MAX_SKIP defaults to 50.
     const parsedSkips = parseInt(process.env.CHRONIK_MAX_SKIP || '50', 10);
@@ -158,7 +158,7 @@ export class RealChronikClient implements ChronikClient {
             if (body.events && body.events.length > 0) {
                 const event = body.events[0];
                 // Filter by types locally
-                if (types.includes(event.type as any)) {
+                if (types.includes(event.type)) {
                     // Match found! Commit cursor and return event
                     this.setCursor(nextCursor);
                     return event;

--- a/src/core/chronik-client.ts
+++ b/src/core/chronik-client.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { ChronikClient, ChronikEvent, EventType, HeimgeistInsightEvent, HeimgeistSelfStateSnapshotEvent } from '../types';
+import { ChronikClient, ChronikEvent, HeimgeistInsightEvent, HeimgeistSelfStateSnapshotEvent } from '../types';
 import { STATE_DIR } from '../config/state-paths';
 
 /**
@@ -83,7 +83,7 @@ export class RealChronikClient implements ChronikClient {
       }
   }
 
-  async nextEvent(types: (EventType | string)[]): Promise<ChronikEvent | null> {
+  async nextEvent(types: string[]): Promise<ChronikEvent | null> {
     // Loop limited to prevent infinite blocking, but high enough to skip sparse streams.
     // CHRONIK_MAX_SKIP defaults to 50.
     const parsedSkips = parseInt(process.env.CHRONIK_MAX_SKIP || '50', 10);

--- a/src/core/chronik-mock.ts
+++ b/src/core/chronik-mock.ts
@@ -21,11 +21,11 @@ export class MockChronikClient implements ChronikClient {
     this.events.push(event);
   }
 
-  async nextEvent(types: string[]): Promise<ChronikEvent | null> {
+  async nextEvent(types: (EventType | string)[]): Promise<ChronikEvent | null> {
     // Simple FIFO for the mock
     if (this.events.length > 0) {
       const event = this.events.shift();
-      if (event && types.includes(event.type as EventType)) {
+      if (event && types.includes(event.type)) {
         return event;
       }
       // If event type doesn't match, maybe put it back or discard?

--- a/src/core/chronik-mock.ts
+++ b/src/core/chronik-mock.ts
@@ -1,4 +1,4 @@
-import { ChronikEvent, EventType, ChronikClient, HeimgeistInsightEvent } from '../types';
+import { ChronikEvent, ChronikClient, HeimgeistInsightEvent } from '../types';
 
 /**
  * Mock Chronik Client for development and testing.

--- a/src/core/chronik-mock.ts
+++ b/src/core/chronik-mock.ts
@@ -21,7 +21,7 @@ export class MockChronikClient implements ChronikClient {
     this.events.push(event);
   }
 
-  async nextEvent(types: (EventType | string)[]): Promise<ChronikEvent | null> {
+  async nextEvent(types: string[]): Promise<ChronikEvent | null> {
     // Simple FIFO for the mock
     if (this.events.length > 0) {
       const event = this.events.shift();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -439,7 +439,7 @@ export interface HeimgeistSelfStateSnapshotEvent {
  * Interface for Chronik Client
  */
 export interface ChronikClient {
-  nextEvent(types: (EventType | string)[]): Promise<ChronikEvent | null>;
+  nextEvent(types: string[]): Promise<ChronikEvent | null>;
   append(event: ChronikEvent | HeimgeistInsightEvent | HeimgeistSelfStateSnapshotEvent): Promise<void>;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -439,7 +439,7 @@ export interface HeimgeistSelfStateSnapshotEvent {
  * Interface for Chronik Client
  */
 export interface ChronikClient {
-  nextEvent(types: string[]): Promise<ChronikEvent | null>;
+  nextEvent(types: (EventType | string)[]): Promise<ChronikEvent | null>;
   append(event: ChronikEvent | HeimgeistInsightEvent | HeimgeistSelfStateSnapshotEvent): Promise<void>;
 }
 


### PR DESCRIPTION
- Update `ChronikClient` interface to use `(EventType | string)[]` for `nextEvent` types
- Update `RealChronikClient` and `MockChronikClient` implementations
- Remove unsafe type casts in event filtering logic