### PR TITLE
🔒 [security] Fix missing authentication in Express API

### DIFF
--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -1,0 +1,102 @@
+import request from 'supertest';
+import express from 'express';
+import { createApp } from './server';
+import { Heimgeist } from '../core';
+import { AutonomyLevel, HeimgeistRole } from '../types';
+
+describe('Heimgeist API Authentication', () => {
+  describe('No API key configured (Fail-Closed)', () => {
+    let app: express.Application;
+
+    beforeEach(() => {
+      const heimgeist = new Heimgeist({
+        autonomyLevel: AutonomyLevel.Warning,
+        activeRoles: [HeimgeistRole.Observer],
+        policies: [],
+        eventSources: [],
+        outputs: [],
+        persistenceEnabled: false,
+        apiKey: undefined,
+      });
+      app = createApp(heimgeist);
+    });
+
+    it('should deny access to /heimgeist/status when no key is configured (401)', async () => {
+      const response = await request(app).get('/heimgeist/status');
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+      expect(response.body.message).toBe('Invalid or missing API key');
+    });
+  });
+
+  describe('API key configured', () => {
+    let app: express.Application;
+    const VALID_KEY = 'test-secret-key';
+
+    beforeEach(() => {
+      const heimgeist = new Heimgeist({
+        autonomyLevel: AutonomyLevel.Warning,
+        activeRoles: [HeimgeistRole.Observer],
+        policies: [],
+        eventSources: [],
+        outputs: [],
+        persistenceEnabled: false,
+        apiKey: VALID_KEY,
+      });
+      app = createApp(heimgeist);
+    });
+
+    it('should deny access to /heimgeist/status without a key (401)', async () => {
+      const response = await request(app).get('/heimgeist/status');
+      expect(response.status).toBe(401);
+    });
+
+    it('should deny access to /heimgeist/status with an incorrect key (401)', async () => {
+      const response = await request(app)
+        .get('/heimgeist/status')
+        .set('X-API-Key', 'wrong-key');
+      expect(response.status).toBe(401);
+    });
+
+    it('should deny access with a key of incorrect length (401)', async () => {
+      // Testing the length-check in constant-time comparison
+      const response = await request(app)
+        .get('/heimgeist/status')
+        .set('X-API-Key', VALID_KEY + '-extra');
+      expect(response.status).toBe(401);
+    });
+
+    it('should allow access to /heimgeist/status with correct X-API-Key header', async () => {
+      const response = await request(app)
+        .get('/heimgeist/status')
+        .set('X-API-Key', VALID_KEY);
+      expect(response.status).toBe(200);
+    });
+
+    it('should allow access to /heimgeist/status with correct Authorization: Bearer header', async () => {
+      const response = await request(app)
+        .get('/heimgeist/status')
+        .set('Authorization', `Bearer ${VALID_KEY}`);
+      expect(response.status).toBe(200);
+    });
+
+    it('should redact the API key in the config output', async () => {
+      const response = await request(app)
+        .get('/heimgeist/config')
+        .set('X-API-Key', VALID_KEY);
+
+      expect(response.status).toBe(200);
+      expect(response.body.apiKey).toBe('[REDACTED]');
+    });
+
+    it('should allow access to public /health even with API key configured', async () => {
+      const response = await request(app).get('/health');
+      expect(response.status).toBe(200);
+    });
+
+    it('should allow access to public root / even with API key configured', async () => {
+      const response = await request(app).get('/');
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -59,7 +59,7 @@ describe('Heimgeist API Authentication', () => {
     });
 
     it('should deny access with a key of incorrect length (401)', async () => {
-      // Testing the length-check in constant-time comparison
+      // Testing the constant-time comparison with different length
       const response = await request(app)
         .get('/heimgeist/status')
         .set('X-API-Key', VALID_KEY + '-extra');
@@ -97,6 +97,39 @@ describe('Heimgeist API Authentication', () => {
     it('should allow access to public root / even with API key configured', async () => {
       const response = await request(app).get('/');
       expect(response.status).toBe(200);
+    });
+  });
+
+  describe('Environment variable API key', () => {
+    let app: express.Application;
+    const ENV_KEY = 'env-secret-key';
+    const originalEnv = process.env.HEIMGEIST_API_KEY;
+
+    beforeEach(() => {
+      process.env.HEIMGEIST_API_KEY = ENV_KEY;
+      // Re-initialize Heimgeist to pick up the new env var in loadConfig
+      const heimgeist = new Heimgeist();
+      app = createApp(heimgeist);
+    });
+
+    afterEach(() => {
+      process.env.HEIMGEIST_API_KEY = originalEnv;
+    });
+
+    it('should allow access with key from environment variable', async () => {
+      const response = await request(app)
+        .get('/heimgeist/status')
+        .set('X-API-Key', ENV_KEY);
+      expect(response.status).toBe(200);
+    });
+
+    it('should redact the environment API key in config', async () => {
+      const response = await request(app)
+        .get('/heimgeist/config')
+        .set('X-API-Key', ENV_KEY);
+
+      expect(response.status).toBe(200);
+      expect(response.body.apiKey).toBe('[REDACTED]');
     });
   });
 });

--- a/src/api/server.test.ts
+++ b/src/api/server.test.ts
@@ -7,6 +7,7 @@ import { EventType, AutonomyLevel, HeimgeistRole } from '../types';
 describe('Heimgeist API Server', () => {
   let app: express.Application;
   let heimgeist: Heimgeist;
+  const TEST_API_KEY = 'test-api-key';
 
   beforeEach(() => {
     heimgeist = new Heimgeist({
@@ -21,9 +22,13 @@ describe('Heimgeist API Server', () => {
       eventSources: [],
       outputs: [],
       persistenceEnabled: false,
+      apiKey: TEST_API_KEY,
     });
     app = createApp(heimgeist);
   });
+
+  // Helper to add auth header to requests
+  const auth = (req: any) => req.set('X-API-Key', TEST_API_KEY);
 
   describe('GET /health', () => {
     it('should return health status', async () => {
@@ -48,7 +53,7 @@ describe('Heimgeist API Server', () => {
 
   describe('GET /heimgeist/status', () => {
     it('should return current status', async () => {
-      const response = await request(app).get('/heimgeist/status');
+      const response = await auth(request(app).get('/heimgeist/status'));
       expect(response.status).toBe(200);
       expect(response.body.version).toBe('1.0.0');
       expect(response.body.autonomyLevel).toBe(AutonomyLevel.Warning);
@@ -58,7 +63,7 @@ describe('Heimgeist API Server', () => {
 
   describe('POST /heimgeist/analyse', () => {
     it('should run an analysis', async () => {
-      const response = await request(app).post('/heimgeist/analyse').send({ depth: 'quick' });
+      const response = await auth(request(app).post('/heimgeist/analyse')).send({ depth: 'quick' });
 
       expect(response.status).toBe(200);
       expect(response.body.id).toBeDefined();
@@ -67,14 +72,14 @@ describe('Heimgeist API Server', () => {
     });
 
     it('should accept analyze spelling', async () => {
-      const response = await request(app).post('/heimgeist/analyze').send({ depth: 'deep' });
+      const response = await auth(request(app).post('/heimgeist/analyze')).send({ depth: 'deep' });
 
       expect(response.status).toBe(200);
       expect(response.body.id).toBeDefined();
     });
 
     it('should use default depth if not provided', async () => {
-      const response = await request(app).post('/heimgeist/analyse').send({});
+      const response = await auth(request(app).post('/heimgeist/analyse')).send({});
 
       expect(response.status).toBe(200);
       expect(response.body.id).toBeDefined();
@@ -83,7 +88,7 @@ describe('Heimgeist API Server', () => {
 
   describe('GET /heimgeist/risk', () => {
     it('should return risk assessment', async () => {
-      const response = await request(app).get('/heimgeist/risk');
+      const response = await auth(request(app).get('/heimgeist/risk'));
       expect(response.status).toBe(200);
       expect(response.body.level).toBeDefined();
       expect(response.body.reasons).toBeInstanceOf(Array);
@@ -93,7 +98,7 @@ describe('Heimgeist API Server', () => {
 
   describe('GET /heimgeist/insights', () => {
     it('should return insights list', async () => {
-      const response = await request(app).get('/heimgeist/insights');
+      const response = await auth(request(app).get('/heimgeist/insights'));
       expect(response.status).toBe(200);
       expect(response.body.insights).toBeInstanceOf(Array);
       expect(response.body.count).toBeDefined();
@@ -101,15 +106,14 @@ describe('Heimgeist API Server', () => {
 
     it('should show insights after processing events', async () => {
       // Submit an event first
-      await request(app)
-        .post('/heimgeist/events')
+      await auth(request(app).post('/heimgeist/events'))
         .send({
           type: EventType.CIResult,
           source: 'test',
           payload: { status: 'failed' },
         });
 
-      const response = await request(app).get('/heimgeist/insights');
+      const response = await auth(request(app).get('/heimgeist/insights'));
       expect(response.status).toBe(200);
       expect(response.body.count).toBeGreaterThan(0);
     });
@@ -117,7 +121,7 @@ describe('Heimgeist API Server', () => {
 
   describe('GET /heimgeist/actions', () => {
     it('should return planned actions list', async () => {
-      const response = await request(app).get('/heimgeist/actions');
+      const response = await auth(request(app).get('/heimgeist/actions'));
       expect(response.status).toBe(200);
       expect(response.body.actions).toBeInstanceOf(Array);
       expect(response.body.count).toBeDefined();
@@ -126,8 +130,7 @@ describe('Heimgeist API Server', () => {
 
   describe('POST /heimgeist/events', () => {
     it('should process a new event', async () => {
-      const response = await request(app)
-        .post('/heimgeist/events')
+      const response = await auth(request(app).post('/heimgeist/events'))
         .send({
           type: EventType.CIResult,
           source: 'github-actions',
@@ -141,7 +144,7 @@ describe('Heimgeist API Server', () => {
     });
 
     it('should generate event ID if not provided', async () => {
-      const response = await request(app).post('/heimgeist/events').send({
+      const response = await auth(request(app).post('/heimgeist/events')).send({
         type: EventType.PROpened,
         payload: {},
       });
@@ -151,14 +154,14 @@ describe('Heimgeist API Server', () => {
     });
 
     it('should use default values for missing fields', async () => {
-      const response = await request(app).post('/heimgeist/events').send({});
+      const response = await auth(request(app).post('/heimgeist/events')).send({});
 
       expect(response.status).toBe(200);
       expect(response.body.eventId).toBeDefined();
     });
 
     it('should reject invalid request body', async () => {
-      const response = await request(app).post('/heimgeist/events').send('invalid');
+      const response = await auth(request(app).post('/heimgeist/events')).send('invalid');
 
       expect(response.status).toBe(400);
       expect(response.body.error).toBeDefined();
@@ -168,8 +171,7 @@ describe('Heimgeist API Server', () => {
   describe('POST /heimgeist/explain', () => {
     it('should explain an insight', async () => {
       // Create an event to generate insights
-      await request(app)
-        .post('/heimgeist/events')
+      await auth(request(app).post('/heimgeist/events'))
         .send({
           type: EventType.CIResult,
           source: 'test',
@@ -178,8 +180,7 @@ describe('Heimgeist API Server', () => {
 
       const insights = heimgeist.getInsights();
       if (insights.length > 0) {
-        const response = await request(app)
-          .post('/heimgeist/explain')
+        const response = await auth(request(app).post('/heimgeist/explain'))
           .send({ insightId: insights[0].id });
 
         expect(response.status).toBe(200);
@@ -188,8 +189,7 @@ describe('Heimgeist API Server', () => {
     });
 
     it('should return 404 for non-existent insight', async () => {
-      const response = await request(app)
-        .post('/heimgeist/explain')
+      const response = await auth(request(app).post('/heimgeist/explain'))
         .send({ insightId: 'non-existent-id' });
 
       expect(response.status).toBe(404);
@@ -199,7 +199,7 @@ describe('Heimgeist API Server', () => {
 
   describe('GET /heimgeist/config', () => {
     it('should return current configuration', async () => {
-      const response = await request(app).get('/heimgeist/config');
+      const response = await auth(request(app).get('/heimgeist/config'));
       expect(response.status).toBe(200);
       expect(response.body.autonomyLevel).toBe(AutonomyLevel.Warning);
       expect(response.body.activeRoles).toBeInstanceOf(Array);
@@ -208,7 +208,7 @@ describe('Heimgeist API Server', () => {
 
   describe('PATCH /heimgeist/config/autonomy', () => {
     it('should update autonomy level', async () => {
-      const response = await request(app).patch('/heimgeist/config/autonomy').send({ level: 3 });
+      const response = await auth(request(app).patch('/heimgeist/config/autonomy')).send({ level: 3 });
 
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
@@ -216,15 +216,14 @@ describe('Heimgeist API Server', () => {
     });
 
     it('should reject invalid autonomy level', async () => {
-      const response = await request(app).patch('/heimgeist/config/autonomy').send({ level: 5 });
+      const response = await auth(request(app).patch('/heimgeist/config/autonomy')).send({ level: 5 });
 
       expect(response.status).toBe(400);
       expect(response.body.error).toBeDefined();
     });
 
     it('should reject non-numeric autonomy level', async () => {
-      const response = await request(app)
-        .patch('/heimgeist/config/autonomy')
+      const response = await auth(request(app).patch('/heimgeist/config/autonomy'))
         .send({ level: 'invalid' });
 
       expect(response.status).toBe(400);
@@ -235,8 +234,7 @@ describe('Heimgeist API Server', () => {
   describe('POST /heimgeist/actions/:id/approve', () => {
     it('should approve a pending action', async () => {
       // Generate a high-severity event to create an action
-      await request(app)
-        .post('/heimgeist/events')
+      await auth(request(app).post('/heimgeist/events'))
         .send({
           type: EventType.IncidentDetected,
           source: 'test',
@@ -245,7 +243,7 @@ describe('Heimgeist API Server', () => {
 
       const actions = heimgeist.getPlannedActions();
       if (actions.length > 0) {
-        const response = await request(app).post(`/heimgeist/actions/${actions[0].id}/approve`);
+        const response = await auth(request(app).post(`/heimgeist/actions/${actions[0].id}/approve`));
 
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
@@ -253,7 +251,7 @@ describe('Heimgeist API Server', () => {
     });
 
     it('should return 404 for non-existent action', async () => {
-      const response = await request(app).post('/heimgeist/actions/non-existent-id/approve');
+      const response = await auth(request(app).post('/heimgeist/actions/non-existent-id/approve'));
 
       expect(response.status).toBe(404);
       expect(response.body.error).toBeDefined();
@@ -263,8 +261,7 @@ describe('Heimgeist API Server', () => {
   describe('POST /heimgeist/actions/:id/reject', () => {
     it('should reject a pending action', async () => {
       // Generate a high-severity event to create an action
-      await request(app)
-        .post('/heimgeist/events')
+      await auth(request(app).post('/heimgeist/events'))
         .send({
           type: EventType.IncidentDetected,
           source: 'test',
@@ -273,7 +270,7 @@ describe('Heimgeist API Server', () => {
 
       const actions = heimgeist.getPlannedActions();
       if (actions.length > 0) {
-        const response = await request(app).post(`/heimgeist/actions/${actions[0].id}/reject`);
+        const response = await auth(request(app).post(`/heimgeist/actions/${actions[0].id}/reject`));
 
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
@@ -281,7 +278,7 @@ describe('Heimgeist API Server', () => {
     });
 
     it('should return 404 for non-existent action', async () => {
-      const response = await request(app).post('/heimgeist/actions/non-existent-id/reject');
+      const response = await auth(request(app).post('/heimgeist/actions/non-existent-id/reject'));
 
       expect(response.status).toBe(404);
       expect(response.body.error).toBeDefined();

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -10,9 +10,6 @@ export function createApiRouter(heimgeist?: Heimgeist): Router {
   const router = Router();
   const instance = heimgeist || createHeimgeist();
 
-  // Middleware to parse JSON
-  router.use(express.json());
-
   // Authentication middleware
   const authMiddleware: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
     let apiKey: string | undefined;
@@ -39,8 +36,11 @@ export function createApiRouter(heimgeist?: Heimgeist): Router {
     }
   };
 
-  // Apply auth middleware to all routes in this router
+  // Apply auth middleware to all routes in this router before body parsing
   router.use(authMiddleware);
+
+  // Middleware to parse JSON (only for authenticated requests)
+  router.use(express.json());
 
   /**
    * POST /heimgeist/analyse

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -13,6 +13,35 @@ export function createApiRouter(heimgeist?: Heimgeist): Router {
   // Middleware to parse JSON
   router.use(express.json());
 
+  // Authentication middleware
+  const authMiddleware: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+    let apiKey: string | undefined;
+
+    // Check X-API-Key header
+    const xApiKey = req.headers['x-api-key'];
+    if (typeof xApiKey === 'string') {
+      apiKey = xApiKey;
+    }
+
+    // Check Authorization header (Bearer token)
+    const authHeader = req.headers['authorization'];
+    if (typeof authHeader === 'string' && authHeader.toLowerCase().startsWith('bearer ')) {
+      apiKey = authHeader.substring(7);
+    }
+
+    if (instance.validateApiKey(apiKey)) {
+      next();
+    } else {
+      res.status(401).json({
+        error: 'Unauthorized',
+        message: 'Invalid or missing API key',
+      });
+    }
+  };
+
+  // Apply auth middleware to all routes in this router
+  router.use(authMiddleware);
+
   /**
    * POST /heimgeist/analyse
    * Run an analysis based on the provided request

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -52,7 +52,7 @@ const DEFAULT_CONFIG: HeimgeistConfig = {
     },
   ],
   persistenceEnabled: true,
-  apiKey: undefined,
+  apiKey: process.env.HEIMGEIST_API_KEY,
 };
 
 /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -52,6 +52,7 @@ const DEFAULT_CONFIG: HeimgeistConfig = {
     },
   ],
   persistenceEnabled: true,
+  apiKey: undefined,
 };
 
 /**
@@ -112,6 +113,7 @@ function mergeConfig(
         ? override.persistenceEnabled
         : defaults.persistenceEnabled,
     artifactsDir: override.artifactsDir !== undefined ? override.artifactsDir : defaults.artifactsDir,
+    apiKey: override.apiKey !== undefined ? override.apiKey : defaults.apiKey,
   };
 }
 
@@ -126,6 +128,7 @@ export function getDefaultConfig(): HeimgeistConfig {
     eventSources: DEFAULT_CONFIG.eventSources.map((e) => ({ ...e })),
     outputs: DEFAULT_CONFIG.outputs.map((o) => ({ ...o })),
     persistenceEnabled: DEFAULT_CONFIG.persistenceEnabled,
+    apiKey: DEFAULT_CONFIG.apiKey,
   };
 }
 

--- a/src/core/heimgeist.ts
+++ b/src/core/heimgeist.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as crypto from 'crypto';
+import * as crypto from 'node:crypto';
 import Ajv, { ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import * as KnowledgeObservatoryContract from '../contracts/vendor/knowledge.observatory.v1.schema.json';
@@ -117,6 +117,11 @@ export class Heimgeist {
         this.logger.warn('Warning: Running RealChronikClient without CHRONIK_TOKEN. Ingest/Poll might fail.');
     }
 
+    // Security check: API Key
+    if (!this.config.apiKey && !process.env.HEIMGEIST_API_KEY) {
+        this.logger.warn('SECURITY WARNING: No API key configured. The API will be unauthenticated.');
+    }
+
     // Runtime Environment Check: fetch API
     if (typeof fetch === 'undefined') {
         this.logger.error('Runtime Error: Global fetch API is not available. Node.js >= 18.17.0 is required.');
@@ -194,6 +199,35 @@ export class Heimgeist {
 
     } catch (error) {
       this.logger.warn(`Failed to refresh state: ${error}`);
+    }
+  }
+
+  /**
+   * Validate an API key against the configuration.
+   * Uses constant-time comparison to prevent timing attacks.
+   * Fail-closed: returns false if no API key is configured.
+   */
+  public validateApiKey(providedKey: string | undefined): boolean {
+    const configuredKey = this.config.apiKey || process.env.HEIMGEIST_API_KEY;
+
+    if (!configuredKey || !providedKey) {
+      return false;
+    }
+
+    try {
+      const configuredBuffer = Buffer.from(configuredKey);
+      const providedBuffer = Buffer.from(providedKey);
+
+      if (configuredBuffer.length !== providedBuffer.length) {
+        // Still perform a comparison to maintain similar timing if possible,
+        // although length check already leaks some info.
+        // timingSafeEqual requires buffers of same length.
+        return false;
+      }
+
+      return crypto.timingSafeEqual(configuredBuffer, providedBuffer);
+    } catch (error) {
+      return false;
     }
   }
 
@@ -1839,6 +1873,7 @@ export class Heimgeist {
           'token',
           'secret',
           'password',
+          'apikey',
           'auth_code',
           'api_key',
           'credential',

--- a/src/core/heimgeist.ts
+++ b/src/core/heimgeist.ts
@@ -119,7 +119,9 @@ export class Heimgeist {
 
     // Security check: API Key
     if (!this.config.apiKey && !process.env.HEIMGEIST_API_KEY) {
-        this.logger.warn('SECURITY WARNING: No API key configured. The API will be unauthenticated.');
+      this.logger.warn(
+        'SECURITY WARNING: No API key configured. Protected /heimgeist/* routes will reject all requests with 401.'
+      );
     }
 
     // Runtime Environment Check: fetch API
@@ -204,7 +206,7 @@ export class Heimgeist {
 
   /**
    * Validate an API key against the configuration.
-   * Uses constant-time comparison to prevent timing attacks.
+   * Uses constant-time comparison (via hashing) to prevent timing attacks.
    * Fail-closed: returns false if no API key is configured.
    */
   public validateApiKey(providedKey: string | undefined): boolean {
@@ -215,17 +217,12 @@ export class Heimgeist {
     }
 
     try {
-      const configuredBuffer = Buffer.from(configuredKey);
-      const providedBuffer = Buffer.from(providedKey);
+      // Use SHA-256 to hash both keys to a fixed length before comparison
+      // to ensure constant-time behavior regardless of input length mismatch.
+      const configuredHash = crypto.createHash('sha256').update(configuredKey).digest();
+      const providedHash = crypto.createHash('sha256').update(providedKey).digest();
 
-      if (configuredBuffer.length !== providedBuffer.length) {
-        // Still perform a comparison to maintain similar timing if possible,
-        // although length check already leaks some info.
-        // timingSafeEqual requires buffers of same length.
-        return false;
-      }
-
-      return crypto.timingSafeEqual(configuredBuffer, providedBuffer);
+      return crypto.timingSafeEqual(configuredHash, providedHash);
     } catch (error) {
       return false;
     }
@@ -1686,6 +1683,7 @@ export class Heimgeist {
       })),
       eventSources: this.config.eventSources.map((source) => ({ ...source })),
       outputs: this.config.outputs.map((output) => ({ ...output })),
+      apiKey: this.config.apiKey || process.env.HEIMGEIST_API_KEY,
     };
     return this.sanitizePayload(config);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -171,6 +171,7 @@ export interface HeimgeistConfig {
   outputs: OutputConfig[];
   persistenceEnabled?: boolean;
   artifactsDir?: string;
+  apiKey?: string;
 }
 
 /**


### PR DESCRIPTION
Implemented a fail-closed API key authentication mechanism for all /heimgeist/* routes using constant-time comparison and supporting multiple header styles (X-API-Key and Authorization: Bearer). Protected endpoints now correctly reject requests if no key is configured or provided. Health and root endpoints remain public. API keys are redacted in configuration exports.